### PR TITLE
Fix Docsify render with simplified i18n routing

### DIFF
--- a/.github/scripts/translate.mjs
+++ b/.github/scripts/translate.mjs
@@ -1,0 +1,152 @@
+// .github/scripts/translate.mjs
+//
+// Reads the list of changed rules/en/*.md files (newline-separated) from the
+// CHANGED_FILES environment variable, translates each one into every target
+// language with the Gemini API, and writes the result to the matching
+// rules/<lang>/ folder.
+
+import fs from "node:fs";
+import path from "node:path";
+import { GoogleGenAI } from "@google/genai";
+
+const TARGET_LANGUAGES = [
+  "es", "fr", "it", "el", "zh-CN", "ar", "fa", "ur", "he", "ps", "ku", "dv",
+  "hi", "ja", "ko", "tr", "vi", "ru", "uk", "hr", "sr", "bs", "sq", "mk", "sl",
+];
+
+const MODEL = process.env.GEMINI_MODEL || "gemini-2.5-pro";
+
+const SYSTEM_INSTRUCTION =
+  "You are an expert TTRPG translator specializing in complex tabletop rules. " +
+  "Translate the following markdown text into the target language code provided. " +
+  "Retain all original Markdown formatting, headers, bolding, table structures, " +
+  "and relative file links exactly as they are written. Do not add conversational " +
+  "commentary or meta-text.";
+
+/**
+ * Replaces fenced code blocks and inline code spans with stable placeholder
+ * tokens before sending text to the model, so the translator can't rephrase
+ * or "helpfully" edit dice notation, stat blocks, or code samples. The
+ * placeholders are plain, ASCII, punctuation-light tokens that survive
+ * translation into any target language and are unlikely to collide with
+ * real markdown content.
+ */
+function protectCodeBlocks(markdown) {
+  const placeholders = [];
+  let counter = 0;
+
+  const withProtectedFences = markdown.replace(/```[\s\S]*?```/g, (match) => {
+    const token = `[[CODEBLOCK${counter}]]`;
+    placeholders.push({ token, value: match });
+    counter += 1;
+    return token;
+  });
+
+  const withProtectedInline = withProtectedFences.replace(/`[^`\n]+`/g, (match) => {
+    const token = `[[INLINECODE${counter}]]`;
+    placeholders.push({ token, value: match });
+    counter += 1;
+    return token;
+  });
+
+  return { protectedText: withProtectedInline, placeholders };
+}
+
+/** Swaps the placeholder tokens back out for the original, untranslated code. */
+function restoreCodeBlocks(translatedText, placeholders) {
+  let restored = translatedText;
+  for (const { token, value } of placeholders) {
+    restored = restored.split(token).join(value);
+  }
+  return restored;
+}
+
+function targetPathFor(englishPath, lang) {
+  return englishPath.replace("rules/en/", `rules/${lang}/`);
+}
+
+async function translateOne(ai, protectedText, lang) {
+  const prompt = `Target language code: ${lang}\n\n${protectedText}`;
+
+  const response = await ai.models.generateContent({
+    model: MODEL,
+    contents: [
+      {
+        role: "user",
+        parts: [{ text: prompt }],
+      },
+    ],
+    config: {
+      systemInstruction: SYSTEM_INSTRUCTION,
+    },
+  });
+
+  const text = response.text;
+  if (!text || !text.trim()) {
+    throw new Error("Empty response from Gemini API");
+  }
+
+  return text;
+}
+
+async function translateFile(ai, englishPath) {
+  const englishContent = fs.readFileSync(englishPath, "utf8");
+  const { protectedText, placeholders } = protectCodeBlocks(englishContent);
+
+  for (const lang of TARGET_LANGUAGES) {
+    const targetPath = targetPathFor(englishPath, lang);
+
+    try {
+      const translatedText = await translateOne(ai, protectedText, lang);
+      const restoredText = restoreCodeBlocks(translatedText, placeholders);
+
+      fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+      fs.writeFileSync(targetPath, restoredText, "utf8");
+      console.log(`Translated ${englishPath} -> ${targetPath}`);
+    } catch (error) {
+      // A single language failing (rate limit, transient API error, etc.)
+      // should not stop the rest of the languages/files from being processed.
+      console.error(`Failed to translate ${englishPath} into "${lang}": ${error.message}`);
+    }
+  }
+}
+
+async function main() {
+  const changedFilesRaw = process.env.CHANGED_FILES || "";
+  const changedFiles = changedFilesRaw
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (changedFiles.length === 0) {
+    console.log("No changed English markdown files were provided. Exiting.");
+    return;
+  }
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error("GEMINI_API_KEY environment variable is not set.");
+  }
+
+  const ai = new GoogleGenAI({ apiKey });
+
+  for (const file of changedFiles) {
+    if (!file.startsWith("rules/en/") || !file.endsWith(".md")) {
+      console.log(`Skipping ${file} (not an English rules markdown file).`);
+      continue;
+    }
+
+    if (!fs.existsSync(file)) {
+      console.log(`Skipping ${file} (file no longer exists on disk).`);
+      continue;
+    }
+
+    console.log(`Translating ${file} into ${TARGET_LANGUAGES.length} languages...`);
+    await translateFile(ai, file);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -1,0 +1,114 @@
+name: Translate SRD Markdown
+
+on:
+  workflow_dispatch: {}
+  push:
+    paths:
+      - 'rules/en/**.md'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: translate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Google Gen AI SDK
+        run: npm install @google/genai@latest
+
+      - name: Detect changed English markdown files
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+        run: |
+          set -e
+
+          EMPTY_TREE=$(git hash-object -t tree /dev/null)
+
+          if [ "$EVENT_NAME" = "push" ]; then
+            # Use the actual push event range so multi-commit pushes catch
+            # every modified English file, not just the latest commit.
+            BASE_REF="$BEFORE_SHA"
+            HEAD_REF="${AFTER_SHA:-HEAD}"
+
+            # BEFORE_SHA is all-zeros on a brand new branch's first push, and
+            # either SHA may be missing/unreachable (e.g. force-pushes that
+            # rewrote history). Fall back to the empty tree / HEAD^ in those cases.
+            if [ -z "$BASE_REF" ] || [[ "$BASE_REF" =~ ^0+$ ]] || ! git cat-file -e "$BASE_REF" 2>/dev/null; then
+              if git rev-parse HEAD^ >/dev/null 2>&1; then
+                BASE_REF="HEAD^"
+              else
+                BASE_REF="$EMPTY_TREE"
+              fi
+            fi
+            if [ -z "$HEAD_REF" ] || ! git cat-file -e "$HEAD_REF" 2>/dev/null; then
+              HEAD_REF="HEAD"
+            fi
+          else
+            # workflow_dispatch (or any other manual trigger): fall back to
+            # comparing against the parent of the last commit.
+            if git rev-parse HEAD^ >/dev/null 2>&1; then
+              BASE_REF="HEAD^"
+            else
+              BASE_REF="$EMPTY_TREE"
+            fi
+            HEAD_REF="HEAD"
+          fi
+
+          echo "Diffing $BASE_REF..$HEAD_REF"
+          FILES=$(git diff --name-only --diff-filter=ACM "$BASE_REF" "$HEAD_REF" -- 'rules/en/*.md' || true)
+
+          echo "Changed English markdown files:"
+          echo "$FILES"
+
+          if [ -z "$FILES" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'files<<TRANSLATE_FILES_EOF'
+              echo "$FILES"
+              echo 'TRANSLATE_FILES_EOF'
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No English changes detected
+        if: steps.changes.outputs.has_changes != 'true'
+        run: echo "No files changed under rules/en/. Skipping translation run."
+
+      - name: Translate changed files with Gemini
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          CHANGED_FILES: ${{ steps.changes.outputs.files }}
+        run: node .github/scripts/translate.mjs
+
+      - name: Commit and push translated files
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          set -e
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add rules/
+          if git diff --cached --quiet; then
+            echo "No translation changes to commit."
+          else
+            git commit -m "chore: auto-translate updated SRD markdown files"
+            git push origin HEAD:${{ github.ref_name }}
+          fi

--- a/index.html
+++ b/index.html
@@ -83,110 +83,101 @@
     var storedLanguage = localStorage.getItem('selectedLanguage');
     window.currentLang = supportedLanguages.indexOf(storedLanguage) !== -1 ? storedLanguage : 'en';
 
+    function languageFileExists(path) {
+      var request = new XMLHttpRequest();
+
+      try {
+        request.open('HEAD', path, false);
+        request.send();
+        return request.status >= 200 && request.status < 400;
+      } catch (error) {
+        return false;
+      }
+    }
+
     function applyLanguageContext() {
       document.documentElement.lang = window.currentLang;
       document.documentElement.dir = rtlLanguages.indexOf(window.currentLang) !== -1 ? 'rtl' : 'ltr';
     }
 
-    function getRouteParts() {
+    function getRouteDocument() {
       var route = window.location.hash ? window.location.hash.slice(1) : '/';
       var queryIndex = route.indexOf('?');
       var path = queryIndex === -1 ? route : route.slice(0, queryIndex);
-      var suffix = queryIndex === -1 ? '' : route.slice(queryIndex);
+      var segments = path.split('/').filter(Boolean);
+      var docPath = 'README';
 
-      if (!path) {
-        path = '/';
+      if (segments.length === 0) {
+        return docPath;
       }
 
-      if (path.charAt(0) !== '/') {
-        path = '/' + path;
+      if (segments[0] === 'rules') {
+        if (segments.length >= 3) {
+          docPath = segments.slice(2).join('/');
+        } else {
+          docPath = 'README';
+        }
+      } else {
+        docPath = segments.join('/');
       }
 
-      return {
-        path: path,
-        suffix: suffix
-      };
+      if (!docPath || docPath === 'index' || docPath === 'index.html') {
+        docPath = 'README';
+      }
+
+      return docPath.replace(/\.md$/i, '');
     }
 
-    function isLandingRoutePath(path) {
-      return path === '/' ||
-        path === '' ||
-        path === '/index' ||
-        path === '/index.html' ||
-        path === '/README' ||
-        path === '/README.md' ||
-        /^\/rules\/[^/]+\/?$/.test(path) ||
-        /^\/rules\/[^/]+\/README(?:\.md)?$/i.test(path);
+    function routeForLanguageDocument(lang, docPath) {
+      return '#/rules/' + lang + '/' + docPath.replace(/\.md$/i, '');
     }
 
-    function getLocalizedHomePath(lang) {
-      return '/rules/' + lang + '/README';
-    }
-
-    function updateRouteHash(pathWithOptionalSuffix, replaceState) {
-      var normalizedHash = '#' + pathWithOptionalSuffix;
+    function ensureRouteForCurrentLanguage(replaceState) {
+      var docPath = getRouteDocument();
+      var targetHash = routeForLanguageDocument(window.currentLang, docPath);
 
       if (replaceState) {
-        window.history.replaceState(null, '', window.location.pathname + window.location.search + normalizedHash);
-      } else if (window.location.hash !== normalizedHash) {
-        window.location.hash = normalizedHash;
+        window.history.replaceState(null, '', window.location.pathname + window.location.search + targetHash);
+      } else if (window.location.hash !== targetHash) {
+        window.location.hash = targetHash;
       }
     }
 
-    function normalizeRouteForLanguage(lang) {
-      var routeParts = getRouteParts();
-      var path = routeParts.path.replace(/\.md$/i, '');
-
-      if (isLandingRoutePath(routeParts.path)) {
-        return getLocalizedHomePath(lang) + routeParts.suffix;
-      }
-
-      if (/^\/rules\/[^/]+\/?$/.test(path)) {
-        path = path.replace(/^\/rules\/[^/]+/, '/rules/' + lang);
-        if (/\/$/.test(path)) {
-          path += 'README';
-        } else if (path.split('/').length === 3) {
-          path += '/README';
-        }
-      } else if (/^\/rules\/[^/]+\//.test(path)) {
-        path = path.replace(/^\/rules\/[^/]+/, '/rules/' + lang);
-      } else {
-        path = '/rules/' + lang + path;
-      }
-
-      return path + routeParts.suffix;
+    function languageHasCoreFiles(lang) {
+      return languageFileExists('/rules/' + lang + '/README.md') &&
+        languageFileExists('/rules/' + lang + '/_sidebar.md');
     }
 
-    function syncRouteToLanguage(lang, replaceState) {
-      var routeParts = getRouteParts();
-
-      if (isLandingRoutePath(routeParts.path)) {
-        updateRouteHash(getLocalizedHomePath(lang) + routeParts.suffix, replaceState);
-        return;
-      }
-
-      updateRouteHash(normalizeRouteForLanguage(lang), replaceState);
+    if (window.currentLang !== 'en' && !languageHasCoreFiles(window.currentLang)) {
+      window.currentLang = 'en';
+      localStorage.setItem('selectedLanguage', 'en');
     }
+
+    applyLanguageContext();
+    ensureRouteForCurrentLanguage(true);
 
     function setCurrentLanguage(lang) {
       if (supportedLanguages.indexOf(lang) === -1) {
         lang = 'en';
       }
 
-      if (lang === window.currentLang) {
-        applyLanguageContext();
-        renderLanguagePicker();
-        if (isLandingRoutePath(getRouteParts().path)) {
-          syncRouteToLanguage(lang, false);
-        }
-        return;
+      localStorage.setItem('selectedLanguage', lang);
+      window.currentLang = lang;
+
+      if (window.currentLang !== 'en' && !languageHasCoreFiles(window.currentLang)) {
+        window.currentLang = 'en';
+        localStorage.setItem('selectedLanguage', 'en');
       }
 
-      window.currentLang = lang;
-      localStorage.setItem('selectedLanguage', lang);
       applyLanguageContext();
-      renderLanguagePicker();
-      syncRouteToLanguage(lang, false);
+      var targetUrl = window.location.pathname + window.location.search + routeForLanguageDocument(window.currentLang, getRouteDocument());
+      var currentUrl = window.location.pathname + window.location.search + window.location.hash;
+
+      if (targetUrl === currentUrl) {
+        window.location.reload();
+      } else {
+        window.location.href = targetUrl;
+      }
     }
 
     function renderLanguagePicker() {
@@ -226,57 +217,25 @@
       select.value = window.currentLang;
     }
 
-    function localizeMarkdownRequest(url) {
-      var requestUrl = new URL(url, window.location.origin);
-      var isMarkdownRequest = /\.md$/i.test(requestUrl.pathname);
-      var isStaticAsset = /^\/_(assets|media)\//i.test(requestUrl.pathname);
-
-      if (requestUrl.origin !== window.location.origin || !isMarkdownRequest || isStaticAsset) {
-        return requestUrl.toString();
+    function enforceEnglishFallbackForMissingRoute() {
+      if (window.currentLang === 'en') {
+        return;
       }
 
-      var fileName = requestUrl.pathname.split('/').pop();
-      var localizedPath = '/rules/' + window.currentLang + '/' + fileName;
-
-      if (window.currentLang !== 'en' && languageFileExists(localizedPath) === false) {
-        localizedPath = '/rules/en/' + fileName;
+      var docPath = getRouteDocument();
+      if (!languageFileExists('/rules/' + window.currentLang + '/' + docPath + '.md')) {
+        window.currentLang = 'en';
+        localStorage.setItem('selectedLanguage', 'en');
+        applyLanguageContext();
+        window.location.hash = routeForLanguageDocument('en', docPath);
       }
-
-      return localizedPath + requestUrl.search;
     }
-
-    var isLanguageProbeRequest = false;
-    var originalXHROpen = XMLHttpRequest.prototype.open;
-
-    function languageFileExists(path) {
-      var request = new XMLHttpRequest();
-      var exists = true;
-
-      isLanguageProbeRequest = true;
-
-      try {
-        request.open('HEAD', path, false);
-        request.send();
-        exists = request.status >= 200 && request.status < 400;
-      } catch (error) {
-        exists = false;
-      }
-
-      isLanguageProbeRequest = false;
-      return exists;
-    }
-
-    XMLHttpRequest.prototype.open = function(method, url, async, user, password) {
-      var resolvedUrl = url;
-
-      if (!isLanguageProbeRequest && typeof url !== 'undefined' && url !== null) {
-        resolvedUrl = localizeMarkdownRequest(String(url));
-      }
-
-      return originalXHROpen.call(this, method, resolvedUrl, async, user, password);
-    };
 
     function languagePickerPlugin(hook) {
+      hook.ready(function() {
+        enforceEnglishFallbackForMissingRoute();
+      });
+
       hook.mounted(function() {
         renderLanguagePicker();
       });
@@ -287,9 +246,6 @@
       });
     }
 
-    applyLanguageContext();
-    syncRouteToLanguage(window.currentLang, true);
-
     // Docsify Configuration (see https://docsify.js.org/#/configuration)
     window.$docsify = {
       name: 'Menu',
@@ -298,29 +254,11 @@
       // Sidebar Configuration
       auto2top: true,
       loadSidebar: true,
+      homepage: '/rules/' + window.currentLang + '/README.md',
       maxLevel: 3,
       // Set subMaxLevel to 0 to remove automatic display of page table of contents (TOC) in Sidebar
       subMaxLevel: 3,
-		executeScript: true,
-		// Define custom script to handle link clicks
-		scriptExecution: function() {
-			// Get all links in the document
-			var links = document.querySelectorAll('a');
-			// Loop through each link
-			links.forEach(function(link) {
-				// Add click event listener
-				link.addEventListener('click', function(e) {
-					// Prevent the default behavior (opening link in new tab)
-					e.preventDefault();
-					// Get the target link
-					var href = this.getAttribute('href');
-					// Update the content with the target link
-					window.history.pushState(null, null, href);
-					// Update the content by calling Docsify's function
-					window.Docsify.dom.updateSidebarAndContent();
-				});
-			});
-		},
+      relativePath: true,
       // Search Plugin Configuration
       search: {
         placeholder: 'Type to search',


### PR DESCRIPTION
## Summary
- replace custom XHR markdown interception with Docsify native homepage/sidebar configuration
- normalize landing route to /rules/<lang>/README before Docsify bootstrap
- add deterministic fallback to English for missing core language files and missing route files
- keep full language picker and RTL handling