### PR TITLE
Add missing Bulgarian (bg) to translation targets

### DIFF
--- a/.github/scripts/translate.mjs
+++ b/.github/scripts/translate.mjs
@@ -13,7 +13,7 @@ import { GoogleGenAI } from "@google/genai";
 const TARGET_LANGUAGES = [
   "es", "fr", "it", "el", "zh-CN", "ar", "fa", "ur", "he", "ps", "ku", "dv",
   "hi", "ja", "ko", "tr", "vi", "ru", "uk", "hr", "sr", "bs", "sq", "mk", "sl",
-  "tl",
+  "tl", "bg",
 ];
 
 // gemini-2.5-pro has a 0-request free-tier quota, so default to the flash


### PR DESCRIPTION
Bulgarian was offered in the language picker but never included in translate.mjs's TARGET_LANGUAGES array, so it was silently skipped every run. Added it.