### PR TITLE
fix: revert translation model to gemini-2.5-flash

### DIFF
--- a/.github/scripts/translate.mjs
+++ b/.github/scripts/translate.mjs
@@ -18,10 +18,11 @@ const TARGET_LANGUAGES = [
   "tl", "bg", "bn", "te", "mr", "ta", "sw", "ha", "ms", "th", "my", "pt",
 ];
 
-// gemini-2.5-flash-lite is the cheapest/fastest model in the 2.5 family that
-// still supports the Batch API, so it's the default for both batch and
-// sequential-fallback requests unless overridden via env var.
-const MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash-lite";
+// gemini-2.5-flash-lite returns a hard 404 ("no longer available to new
+// users") against this project's API key, so we're back on gemini-2.5-flash,
+// the model that has been reliably translating this repo's content. Override
+// via env var if a cheaper/newer model becomes available.
+const MODEL = process.env.GEMINI_MODEL || "gemini-2.5-flash";
 
 // Max attempts (including the first try) per language before giving up and
 // logging a final failure. Used by the sequential fallback path.


### PR DESCRIPTION
gemini-2.5-flash-lite returns a hard 404 (not available to new users) against this project's Gemini API key, which caused every single translation call to fail (both the new Batch API path and its sequential fallback) in a live test run of PR #127. Restores gemini-2.5-flash as the default model, which has reliably translated this repo for months, while keeping GEMINI_MODEL env override available.