### PR TITLE
Add top navbar

### DIFF
--- a/rules/en/_navbar.md
+++ b/rules/en/_navbar.md
@@ -1,0 +1,4 @@
+- [Home](/)
+- [How To](HowTo.md)
+- [Changelog](Changelog.md)
+- [GitHub](https://github.com/raleel/mythras-srd)


### PR DESCRIPTION
Adds rules/en/_navbar.md so the top navbar (Home / How To / Changelog / GitHub) renders, matching cfi-srd. index.html already had loadNavbar: true and the per-language navbar alias fallback wired up - it just had no source file to load. Other languages will get translated copies automatically on the next translation pipeline run.